### PR TITLE
feat: attribute whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ visualHTML(document.body, { shallow: true }); // Returns just visual information
 ## How it works
 
 `visual-html` works by building up an HTML representation of the DOM including only attributes that account for the visual display of the element.
-It will scan through all style sheets and inline the applied styles for an element, and strip any attributes that do not come with user agent styles.
+It will scan through all style sheets and inline the applied styles for an element. Then it reads all properties that change the visuals of the element and includes the corresponding attribute in the HTML snapshot.
 
 Lets look at an example.
 
@@ -120,14 +120,12 @@ visualHTML(div); // Returns the html below as string.
 ```
 
 ```html
-<div
-  style="
-  transform: translateX(-100px);
-  width: 100px;
+<div style="
+  background: red;
   height: 200px;
-  background: red
-"
->
+  transform: translateX(-100px);
+  width: 100px
+">
   <span style="color: #333">
     Hello!
   </span>
@@ -138,7 +136,7 @@ visualHTML(div); // Returns the html below as string.
     </label>
     <label>
       Password:
-      <input />
+      <input type="password"/>
     </label>
     <label>
       Remember Me:
@@ -151,7 +149,7 @@ visualHTML(div); // Returns the html below as string.
 </div>
 ```
 
-In the above output you can see that the majority of attributes have been removed, and styles are now included inline. The `type="checkbox"` is still present on the `Remember Me:` checkbox as it causes the browser to display the textbox differently. The default `type` for an `input` is `text`, and a `type="password"` is visually identical to `type="text"` unless you've styled it differently yourself in which case an inline style attribute would be present.
+In the above output you can see that the majority of attributes have been removed, and styles are now included inline. The `type="text"` on the first `input` was removed since it is a default. All attributes and properties are also sorted alphabetically to be more stable.
 
 ## How is this different than x!?
 

--- a/src/__tests__/examples.ts
+++ b/src/__tests__/examples.ts
@@ -44,34 +44,34 @@ test("runs the first example", () => {
     `
     )
   ).toMatchInlineSnapshot(`
-        "<div style=\\"
-          transform: translateX(-100px);
-          width: 100px;
-          height: 200px;
-          background: red
-        \\">
-          <span style=\\"color: #333\\">
-            Hello!
-          </span>
-          <form>
-            <label>
-              Username:
-              <input/>
-            </label>
-            <label>
-              Password:
-              <input/>
-            </label>
-            <label>
-              Remember Me:
-              <input type=\\"checkbox\\"/>
-            </label>
-            <button>
-              Sign in
-            </button>
-          </form>
-        </div>"
-    `);
+    "<div style=\\"
+      background: red;
+      height: 200px;
+      transform: translateX(-100px);
+      width: 100px
+    \\">
+      <span style=\\"color: #333\\">
+        Hello!
+      </span>
+      <form>
+        <label>
+          Username:
+          <input/>
+        </label>
+        <label>
+          Password:
+          <input type=\\"password\\"/>
+        </label>
+        <label>
+          Remember Me:
+          <input type=\\"checkbox\\"/>
+        </label>
+        <button>
+          Sign in
+        </button>
+      </form>
+    </div>"
+  `);
 });
 
 test("works with diff snapshots", () => {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 test("removes any properties that do not apply user agent styles", () => {
   expect(
     testHTML(`
-      <input type="text" class="other"/>
+      <input type="text" class="other" checked/>
     `)
   ).toMatchInlineSnapshot(`"<input/>"`);
 });
@@ -31,9 +31,14 @@ test("removes any properties that do not apply user agent styles", () => {
 test("preserves any properties that do apply user agent styles", () => {
   expect(
     testHTML(`
-      <input type="search" class="other"/>
+      <input type="checkbox" class="other" checked/>
     `)
-  ).toMatchInlineSnapshot(`"<input type=\\"search\\"/>"`);
+  ).toMatchInlineSnapshot(`
+    "<input
+      checked
+      type=\\"checkbox\\"
+    />"
+  `);
 });
 
 test("preserves any inline styles", () => {
@@ -58,11 +63,11 @@ test("inline styles override applied styles", () => {
       `
     )
   ).toMatchInlineSnapshot(`
-        "<div style=\\"
-          color: green;
-          background: red
-        \\"/>"
-    `);
+    "<div style=\\"
+      background: red;
+      color: green
+    \\"/>"
+  `);
 });
 
 test("accounts for !important", () => {
@@ -80,8 +85,8 @@ test("accounts for !important", () => {
     )
   ).toMatchInlineSnapshot(`
     "<div style=\\"
-      color: green !important;
-      background: blue !important
+      background: blue !important;
+      color: green !important
     \\"/>"
   `);
 });
@@ -135,12 +140,12 @@ test("supports multiple applied styles", () => {
       `
     )
   ).toMatchInlineSnapshot(`
-            "<div style=\\"
-              color: blue;
-              background-color: red;
-              font-size: 1rem
-            \\"/>"
-      `);
+    "<div style=\\"
+      background-color: red;
+      color: blue;
+      font-size: 1rem
+    \\"/>"
+  `);
 });
 
 test("includes children", () => {
@@ -275,22 +280,22 @@ test("includes pseudo elements", () => {
   `;
 
   expect(testHTML(html, styles)).toMatchInlineSnapshot(`
-                    "<div>
-                      <style scoped>
-                        ::selection {background: red}
-                        ::after {
-                          content: \\"hello\\";
-                          color: green
-                        }
-                      </style>
-                      <span>
-                        <style scoped>
-                          ::selection {background: blue}
-                        </style>
-                        Content
-                      </span>
-                    </div>"
-          `);
+    "<div>
+      <style scoped>
+        ::after {
+          color: green;
+          content: \\"hello\\"
+        }
+        ::selection {background: red}
+      </style>
+      <span>
+        <style scoped>
+          ::selection {background: blue}
+        </style>
+        Content
+      </span>
+    </div>"
+  `);
 });
 
 function testHTML(html: string, styles: string = "") {

--- a/src/html-properties.ts
+++ b/src/html-properties.ts
@@ -1,0 +1,283 @@
+export const HTML_PROPERTIES = {
+  align: {
+    alias: false,
+    tests: [
+      test([
+        "applet",
+        "caption",
+        "col",
+        "colgroup",
+        "hr",
+        "iframe",
+        "img",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr"
+      ])
+    ]
+  },
+  autoplay: {
+    alias: false,
+    tests: [test(["audio", "video"])]
+  },
+  background: {
+    alias: false,
+    tests: [test(["body", "table", "td", "th"])]
+  },
+  bgColor: {
+    alias: "bgcolor",
+    tests: [
+      test([
+        "body",
+        "col",
+        "colgroup",
+        "table",
+        "tbody",
+        "tfoot",
+        "td",
+        "th",
+        "tr"
+      ])
+    ]
+  },
+  border: {
+    alias: false,
+    tests: [test(["img", "object", "table"])]
+  },
+  checked: {
+    alias: false,
+    tests: [
+      test("input", (it: HTMLInputElement) =>
+        /^(?:checkbox|radio)$/.test(it.type))
+    ]
+  },
+  color: {
+    alias: false,
+    tests: [test(["basefont", "font", "hr"])]
+  },
+  cols: {
+    alias: false,
+    tests: [test("textarea")]
+  },
+  colSpan: {
+    alias: "colspan",
+    tests: [test(["td", "th"])]
+  },
+  controls: {
+    alias: false,
+    tests: [test(["audio", "video"])]
+  },
+  coords: {
+    alias: false,
+    tests: [test("area")]
+  },
+  currentSrc: {
+    alias: "src",
+    tests: [test(["audio", "img", "source", "video"])]
+  },
+  data: {
+    alias: false,
+    tests: [test("object")]
+  },
+  default: {
+    alias: false,
+    tests: [test("track")]
+  },
+  dir: {
+    alias: false,
+    tests: [test(/./)]
+  },
+  disabled: {
+    alias: false,
+    tests: [
+      test([
+        "button",
+        "fieldset",
+        "input",
+        "optgroup",
+        "option",
+        "select",
+        "textarea"
+      ])
+    ]
+  },
+  height: {
+    alias: false,
+    tests: [
+      test(["canvas", "embed", "iframe", "img", "input", "object", "video"])
+    ]
+  },
+  hidden: {
+    alias: false,
+    tests: [test(/./)]
+  },
+  high: {
+    alias: false,
+    tests: [test("meter")]
+  },
+  inputMode: {
+    alias: "inputmode",
+    tests: [
+      test("textarea"),
+      test(/./, (it: HTMLElement) => it.isContentEditable)
+    ]
+  },
+  kind: {
+    alias: false,
+    tests: [test("track")]
+  },
+  label: {
+    alias: false,
+    tests: [test(["optgroup", "option", "track"])]
+  },
+  loop: {
+    alias: false,
+    tests: [test(["audio", "video"])]
+  },
+  low: {
+    alias: false,
+    tests: [test("meter")]
+  },
+  max: {
+    alias: false,
+    tests: [test("input", isInputWithBoundaries), test(["meter", "progress"])]
+  },
+  maxLength: {
+    alias: "maxlength",
+    tests: [test("input", isInputWithPlainText), test("textarea")]
+  },
+  minLength: {
+    alias: "minlength",
+    tests: [test("input", isInputWithPlainText), test("textarea")]
+  },
+  min: {
+    alias: false,
+    tests: [test("meter"), test("input", isInputWithBoundaries)]
+  },
+  multiple: {
+    alias: false,
+    tests: [
+      test("input", (it: HTMLInputElement) => it.type === "file"),
+      test("select")
+    ]
+  },
+  open: {
+    alias: false,
+    tests: [test(["details", "dialog"])]
+  },
+  optimum: {
+    alias: false,
+    tests: [test("meter")]
+  },
+  placeholder: {
+    alias: false,
+    tests: [test(["input", "textarea"])]
+  },
+  poster: {
+    alias: false,
+    tests: [test("video")]
+  },
+  readOnly: {
+    alias: "readonly",
+    tests: [test(["input", "textarea"])]
+  },
+  reversed: {
+    alias: false,
+    tests: [test("ol")]
+  },
+  rows: {
+    alias: false,
+    tests: [test("textarea")]
+  },
+  rowSpan: {
+    alias: "rowspan",
+    tests: [test(["td", "th"])]
+  },
+  selected: {
+    alias: false,
+    tests: [test("option")]
+  },
+  size: {
+    alias: false,
+    tests: [test("input", isInputWithPlainText), test("select")]
+  },
+  span: {
+    alias: false,
+    tests: [test(["col", "colgroup"])]
+  },
+  src: {
+    alias: false,
+    tests: [test(["embed", "iframe", "track"])]
+  },
+  srcdoc: {
+    alias: false,
+    tests: [test("iframe")]
+  },
+  sizes: {
+    alias: false,
+    tests: [test(["img", "source"])]
+  },
+  start: {
+    alias: false,
+    tests: [test("ol")]
+  },
+  title: {
+    alias: false,
+    tests: [test("abbr")]
+  },
+  type: {
+    alias: false,
+    tests: [test("input"), test("ol")]
+  },
+  value: {
+    alias: false,
+    tests: [
+      test("input", (it: HTMLInputElement) =>
+        /^(?!checkbox|radio)$/.test(it.type)),
+      test(["meter", "progress"]),
+      test("li", (it: HTMLLIElement) => it.parentElement!.localName === "ol")
+    ]
+  },
+  width: {
+    alias: false,
+    tests: [
+      test(["canvas", "embed", "iframe", "img", "input", "object", "video"])
+    ]
+  },
+  wrap: {
+    alias: false,
+    tests: [test("textarea")]
+  }
+} as const;
+
+function isInputWithBoundaries(input: HTMLInputElement) {
+  return /^(?:number|range|date|datetime-local|year|month|week|day|time)$/.test(
+    input.type
+  );
+}
+
+function isInputWithPlainText(input: HTMLInputElement) {
+  return /^(?:text|search|tel|email|password|url)$/.test(input.type);
+}
+
+function test<T extends Element>(
+  localNames: RegExp | string[] | string,
+  check: (instance: T) => boolean = pass
+) {
+  if (typeof localNames === "string") {
+    localNames = [localNames];
+  }
+
+  const reg = Array.isArray(localNames)
+    ? new RegExp(`^(?:${localNames.join("|")})$`)
+    : localNames;
+  return (instance: T) => reg.test(instance.localName) && check(instance);
+}
+
+function pass() {
+  return true;
+}

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -37,7 +37,10 @@ function printAttributes(data: VisualData) {
 
   if (attributes) {
     for (const { name, value } of attributes) {
-      parts.push(name + (value === "" ? "" : `=${JSON.stringify(value)}`));
+      parts.push(
+        name +
+          (value === true || value === "" ? "" : `=${JSON.stringify(value)}`)
+      );
     }
   }
 
@@ -45,7 +48,7 @@ function printAttributes(data: VisualData) {
     parts.push(printStyle(data));
   }
 
-  return parts;
+  return parts.sort();
 }
 
 function printStyle({ styles }: VisualData) {
@@ -71,6 +74,7 @@ function printPseudoElements(data: VisualData) {
   }
 
   return `<style scoped>\n${Object.keys(pseudoStyles)
+    .sort()
     .map(name =>
       indent(
         `${name} {${printProperties(pseudoStyles[name])}}`,
@@ -90,5 +94,5 @@ function printProperties(styles: { [x: string]: string }) {
 
   return parts.length === 1
     ? parts[0]
-    : `\n${indent(parts.join(";\n"), 1, indentOptions)}\n`;
+    : `\n${indent(parts.sort().join(";\n"), 1, indentOptions)}\n`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ declare global {
 
 export interface VisualData {
   tagName: string;
-  attributes: Array<{ name: string; value: string }> | null;
+  attributes: Array<{ name: string; value: string | boolean | null }> | null;
   styles: { [x: string]: string } | null;
   pseudoStyles: { [x: string]: { [x: string]: string } } | null;
   children: Array<VisualData | string> | null;


### PR DESCRIPTION
## Description

Switches the attribute preserving mechanism to use a whitelist for the html namespace and a blacklist for other namespaces.

## Motivation and Context

The previous implementation of checking for computed style changes caused by each attribute caused too many false negatives. It also did not properly handle stateful properties such as `input value`. This new solutions handles all known attributes that effect visibility and instead checks for their property to grab the most current value.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
