### PR TITLE
fix(stylesheets): added a check in case the styles are empty

### DIFF
--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -140,10 +140,19 @@ function getAppliedStylesForElement(
 
   for (const style of styles) {
     for (let i = 0, len = style.length; i < len; i++) {
-      const name = style[i];
-      const value = style.getPropertyValue(name);
+      let name = style[i];
+      let value = style.getPropertyValue(name);
+      while(value === "") {
+        const dashIndex = name.lastIndexOf("-");
+        if (dashIndex !== -1) {
+          name = name.slice(0, dashIndex);
+          value = style.getPropertyValue(name);
+        } else {
+          break;
+        }
+      }
 
-      if (value !== "initial" && value !== defaults[name]) {
+      if (value !== "initial" && value !== "" && value !== defaults[name]) {
         const isImportant = style.getPropertyPriority(name) === "important";
 
         if (properties) {


### PR DESCRIPTION

## Description
* If a style is empty and default was not matching empty, it was being added. 

## Motivation and Context
Seems like it might be due to a bug in vitest because I could not reproduce this in jest. 

## Screenshots (if appropriate):

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
