### PR TITLE
chore: update "includes pseudo elements" snapshot

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -307,6 +307,7 @@ test("includes pseudo elements", () => {
       }}</style>
       <span>
         <style>@scope{:scope{
+          &::before {display: block}
           &::selection {background: blue}
         }}</style>
         Content


### PR DESCRIPTION
The unit tests are failing because the "includes psuedo elements" test is failing, this PR updates the test snapshot so the tests pass.

Arguably, the `display: block` rule _should_ be omitted from snapshot because there is no `content` in the `before` block...