### PR TITLE
fix: only include pseudo elements that render

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -291,7 +291,8 @@ test("includes pseudo elements", () => {
       background: green;
     }
 
-    div ::before {
+    .test ::before {
+      content: "";
       display: block;
     }
   `;
@@ -307,10 +308,50 @@ test("includes pseudo elements", () => {
       }}</style>
       <span>
         <style>@scope{:scope{
+          &::before {
+            content: \\"\\";
+            display: block
+          }
           &::selection {background: blue}
         }}</style>
         Content
       </span>
+    </div>"
+  `);
+});
+
+test("pseudo elements only included when they render", () => {
+  const html = `
+    <div class="test"><div class="other">Content</div></div>
+  `;
+
+  const styles = `
+    .test::before { content: "prefix"; color: blue; }
+    .test::after { content: ""; color: red; }
+    .test::selection { background: yellow; }
+    .test::first-line { font-weight: bold; }
+    
+    .other::before { display: block; }
+    .other::after { content: none; color: red; }
+  `;
+
+  expect(testHTML(html, styles)).toMatchInlineSnapshot(`
+    "<div>
+      <style>@scope{:scope{
+        &::after {
+          color: red;
+          content: \\"\\"
+        }
+        &::before {
+          color: blue;
+          content: \\"prefix\\"
+        }
+        &::first-line {font-weight: bold}
+        &::selection {background: yellow}
+      }}</style>
+      <div>
+        Content
+      </div>
     </div>"
   `);
 });

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -94,13 +94,31 @@ export function getPseudoElementStyles(
       name,
       stylesByPseudoElement[name]
     );
-    if (styles) {
+    if (styles && shouldIncludePseudoElement(name, styles)) {
       appliedPseudoElementStyles ||= {};
       appliedPseudoElementStyles[name] = styles;
     }
   }
 
   return appliedPseudoElementStyles;
+}
+
+function shouldIncludePseudoElement(
+  pseudoName: string,
+  styles: { [property: string]: string }
+): boolean {
+  if (pseudoName !== "::before" && pseudoName !== "::after") {
+    // Other pseudo-elements (::selection, ::first-line, etc.) should always be included.
+    return true;
+  }
+
+  const contentValue = styles.content;
+
+  // Pseudo-element renders if:
+  // - content property exists (not undefined).
+  // - content: "" (empty string).
+  // - content is not "none".
+  return contentValue !== undefined && contentValue !== "none";
 }
 
 /**


### PR DESCRIPTION
Alternative to https://github.com/eBay/visual-html/pull/34.

When a `::before` or `::after` pseudo-element has no content, it doesn't get rendered, so we can safely omit it from the snapshot.